### PR TITLE
Specify `/tmp` directory as a temporary file location to officeParser and log proper messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,12 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Ignore all tempfiles.
+/tmp/*
+!/tmp/.keep
+
+# Ignore tempfiles, but keep the directory.
+/tmp/officeParser/*
+!/tmp/officeParser/
+!/tmp/officeParser/.keep

--- a/.gitignore
+++ b/.gitignore
@@ -34,12 +34,3 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-
-# Ignore all tempfiles.
-/tmp/*
-!/tmp/.keep
-
-# Ignore tempfiles, but keep the directory.
-/tmp/officeParser/*
-!/tmp/officeParser/
-!/tmp/officeParser/.keep

--- a/app/api/slidesToText/route.ts
+++ b/app/api/slidesToText/route.ts
@@ -26,15 +26,20 @@ export async function POST(req: Request): Promise<Response> {
     return new Response(JSON.stringify({ status: "ok", text }), {
       headers: { "Content-Type": "application/json" },
     });
-  } catch (error) {
-    let message = "Error during text extraction.";
-    if (error instanceof Error) {
-      message += " " + error.message;
-    }
+  } catch (error: unknown) {
+    console.error("slidesToText POST function failed:", error);
 
-    return new Response(JSON.stringify({ status: "error", message: message }), {
-      headers: { "Content-Type": "application/json" },
-      status: 500,
-    });
+    const responseMessage =
+      error instanceof Error
+        ? error.message
+        : "An internal error occurred. Please try again later.";
+
+    return new Response(
+      JSON.stringify({ status: "error", message: responseMessage }),
+      {
+        headers: { "Content-Type": "application/json" },
+        status: 500,
+      }
+    );
   }
 }

--- a/components/PresentationFileUploader.tsx
+++ b/components/PresentationFileUploader.tsx
@@ -34,9 +34,9 @@ export function PresentationFileUploader({
             const data = JSON.parse(response);
             if (data.status === "ok") {
               onFileProcessed(data.text);
-              return "Success file processing!";
+              return 1; // No meaning. But it needs to return number or string
             } else {
-              return `Error during file processing. ${data.message}`;
+              return 0; // No meaning. But it needs to return number or string
             }
           },
           onerror: (error) => {


### PR DESCRIPTION
Issue https://github.com/my-joshu/my-joshu/issues/23

I want to try these fixes. I am not 100% sure, but I think this works because of the following reasons. While I was at it, I organized error messages for debug use.

## Hypothesis

### Vercel

We need to use `/tmp` when writing files on Vercel. Because:

> Serverless Functions have a read-only filesystem with writable /tmp scratch space up to 500 MB.
> https://vercel.com/docs/functions/runtimes#file-system-support

### officeParser

officeParser makes "officeParserTemp" for temp files as default, but on Vercel, it can't access any files with write permission except `/tmp` directory. So, I specified `/tmp` directory to `parseOfficeAsync` method to be able to write the files

See: `parseOffice` method in officeParser writes new files
https://github.com/harshankur/officeParser/blob/0733d9a7bd6fb7449e6a860347486c70cae6c5b0/officeParser.js#L508